### PR TITLE
Change the doctrine-bundle version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=7.1.3",
         "symfony/framework-bundle": "^3.0 || ^4.0",
-        "doctrine/doctrine-bundle": "~1.3",
+        "doctrine/doctrine-bundle": "^1.3",
         "sonata-project/admin-bundle": "^3.2",
         "sonata-project/doctrine-orm-admin-bundle": "^3.1"
     },


### PR DESCRIPTION
With the actual `"doctrine/doctrine-bundle": "~1.3"`, `composer update` returns an error.