### PR TITLE
Make 'Menu Items' button translatable

### DIFF
--- a/Resources/views/CRUD/list__action_edit_items.html.twig
+++ b/Resources/views/CRUD/list__action_edit_items.html.twig
@@ -1,3 +1,3 @@
 <a class="btn btn-sm btn-default items_link" href="{{ admin.generateObjectUrl('items', object) }}" title="Menu Items">
-    <i class="fa fa-bars" aria-hidden="true"></i> Menu Items
+    <i class="fa fa-bars" aria-hidden="true"></i>{% trans from "ProdigiousSonataMenuBundle" %}config.label_menu_items{% endtrans %}
 </a>


### PR DESCRIPTION
The **Menu Items** button on the main menu list is not translatable as of now. Make it translatable through the `config.label_menu_items` key.