### PR TITLE
Fix compatibility with recent symfony/yaml changes

### DIFF
--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -26,7 +26,7 @@ services:
         tags:
             - { name: sonata.admin, manager_type: orm, label: config.label_menu, group: config.label_menu, label_catalogue: ProdigiousSonataMenuBundle }
         calls:
-            - [ setTranslationDomain, [ProdigiousSonataMenuBundle]]  
+            - [ setTranslationDomain, ['ProdigiousSonataMenuBundle']]  
             - [ addChild, ['@prodigious_sonata_menu.admin.menu_item', 'menu']]
             
     prodigious_sonata_menu.admin.menu_item:
@@ -35,4 +35,4 @@ services:
         tags:
             - { name: sonata.admin, manager_type: orm, label: config.label_menu_item, group: config.label_menu, show_in_dashboard: false, label_catalogue: ProdigiousSonataMenuBundle }
         calls:
-            - [ setTranslationDomain, [ProdigiousSonataMenuBundle]]
+            - [ setTranslationDomain, ['ProdigiousSonataMenuBundle']]


### PR DESCRIPTION
Recent changes to the Symfony YamlFileLoader in the symfony/yaml package made it so that these string values must be quoted. This should have zero breaking changes for lower versions because the string conversion was implied before anyway, now it's just explicit.